### PR TITLE
Added Facebook response redirect.

### DIFF
--- a/src/main/java/facebook4j/examples/signin/LogoutServlet.java
+++ b/src/main/java/facebook4j/examples/signin/LogoutServlet.java
@@ -11,8 +11,16 @@ public class LogoutServlet extends HttpServlet {
     private static final long serialVersionUID = 5357658337449255998L;
 
     @Override
-    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {      
+        Facebook facebook = (Facebook) request.getSession().getAttribute("facebook");
+        String accessToken = "";
+        try {
+        	accessToken = facebook.getOAuthAccessToken().getToken();
+        } catch (Exception e) {
+            throw new ServletException(e);
+        }
         request.getSession().invalidate();
-        response.sendRedirect(request.getContextPath()+ "/");
+        //siteurl.com should match your facebook app settings
+        response.sendRedirect("http://www.facebook.com/logout.php?next=http://www.siteurl.com/index.html&access_token=" + accessToken);
     }
 }


### PR DESCRIPTION
I tried the logout example with my facebook app and compared it to how I made with RestFb. The current logoutservlet isn't logging out correct.

The provided code is just an example. I haven't tried the exception for all cases.
siteurl.com could probably be replaced with request.getContextPath() but with logoutservlet removed at the end.

See this link for more information
http://stackoverflow.com/questions/2764436/facebook-oauth-logout
